### PR TITLE
モバイル版でポリシーと規約にpaddingがないのを修正

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -792,11 +792,9 @@ footer ul li:nth-child(n + 4) a {
   font-weight: normal;
 }
 
-@media screen and (min-width: 600px) {
-  .policy,
-  .terms {
-    padding: calc(9vh + 3%) 10%;
-  }
+.policy,
+.terms {
+  padding: calc(9vh + 3%) 10%;
 }
 
 .policy h1,


### PR DESCRIPTION
ポリシーと利用規約のpaddingに、モバイル版で無効なメディアクエリを設定していたので消去