### PR TITLE
ビルド時にメンバーの画像が表示されない問題を修正

### DIFF
--- a/src/components/MemberItem.vue
+++ b/src/components/MemberItem.vue
@@ -47,7 +47,7 @@ export default defineComponent({
     },
   },
   setup: async (props) => {
-    const img = ref<string>((await import(props.imagePath)).default);
+    const img = ref((await import(`../images/${props.imagePath}.jpg`)).default);
     return {
       img,
     };

--- a/src/organisms/Member.vue
+++ b/src/organisms/Member.vue
@@ -4,7 +4,7 @@
     <Suspense>
       <div class="member__content">
         <MemberItem
-          imagePath="../images/takonasu.jpg"
+          imagePath="takonasu"
           name="たこなす"
           desc="発起人。iOS、総務担当。
 筑波大学情報科学類所属。
@@ -16,7 +16,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/hikaruegashira.jpg"
+          imagePath="hikaruegashira"
           name="HikaruEgashira"
           desc="フロントエンド担当。
 筑波大学情報科学類所属。
@@ -28,7 +28,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/siy1121.jpg"
+          imagePath="siy1121"
           name="SIY1121"
           desc="バックエンド・Android担当。
 筑波大学情報科学類所属。
@@ -40,7 +40,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/kanadenishizawa.jpg"
+          imagePath="kanadenishizawa"
           name="KanadeNishizawa"
           desc="デザイン担当。
 筑波大学芸術専門学群所属。
@@ -56,7 +56,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/takonomura.jpg"
+          imagePath="takonomura"
           name="takonomura"
           desc="インフラ担当。
 筑波大学情報科学類所属。
@@ -68,7 +68,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/hosokawar.jpg"
+          imagePath="hosokawar"
           name="HosokawaR"
           desc="フロントエンド担当。
 筑波大学情報科学類所属。
@@ -80,7 +80,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/hayatoshishido.jpg"
+          imagePath="hayatoshishido"
           name="HayatoShishido"
           desc="フロントエンド担当。
 筑波大学応用理工学群所属。
@@ -92,7 +92,7 @@
           }"
         ></MemberItem>
         <MemberItem
-          imagePath="../images/yuku.jpg"
+          imagePath="yuku"
           name="ゆうく"
           desc="バックエンド担当。
 無職。


### PR DESCRIPTION
ビルド時にも正常にメンバーの画像が表示されるようにしました。
![image](https://user-images.githubusercontent.com/45098934/113357555-21ac4600-937f-11eb-8568-7d4087d1fe08.png)
原因は僕が`vite`の`import`ルールに従うのを忘れていたことです。。。
https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations