### PR TITLE
横スクロールバーがでるので width 100% に修正

### DIFF
--- a/src/organisms/Top.vue
+++ b/src/organisms/Top.vue
@@ -55,7 +55,7 @@ export default defineComponent({
 @import "~/scss/main.scss";
 
 .top {
-  width: 100vw;
+  width: 100%;
   @include pc {
     height: 50vw;
   }
@@ -77,7 +77,7 @@ export default defineComponent({
       left: 0;
     }
     @include tablet {
-      width: 100vw;
+      width: 100%;
     }
     @include sp {
       width: 57rem;


### PR DESCRIPTION
windwos chrome の場合 `100vw` はスクロールバーを考慮しないので、画像のように横スクロールが発生します。
`100%`にすることで修正しました。
↓横スクロールバーあり
![image](https://user-images.githubusercontent.com/45098934/113393321-7678ac80-93d1-11eb-8555-10086c246dae.png)
↓横スクロールバーなし
![image](https://user-images.githubusercontent.com/45098934/113393386-914b2100-93d1-11eb-8d1c-d947451bc679.png)
