### PR TITLE
CI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: [push]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use yarn global cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          CI: true
+
+      - name: format
+        run: yarn format:check
+        env:
+          CI: true
+
+      - name: Generate
+        run: yarn generate
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preview": "nuxt preview",
     "typecheck": "vue-tsc --noEmit",
     "format:fix": "prettier ./src --write",
+    "format:check": "prettier ./src --check",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {

--- a/src/plugins/vue-gtag.client.js
+++ b/src/plugins/vue-gtag.client.js
@@ -1,11 +1,11 @@
-import VueGtag, { trackRouter } from 'vue-gtag-next'
+import VueGtag, { trackRouter } from 'vue-gtag-next';
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueGtag, {
     property: {
       id: 'GTM-W65BSBG',
     },
-    isEnabled: import.meta.env.PROD, 
-  })
-  trackRouter(useRouter())
-})
+    isEnabled: import.meta.env.PROD,
+  });
+  trackRouter(useRouter());
+});


### PR DESCRIPTION
なにげに CI が存在していなかったので追加しました。

Twin:te Front の CI を参考にしつつ、action/checkout のバージョンを v2 → v3 にあげています。
ref: https://github.com/twin-te/twinte-front/blob/main/.github/workflows/ci.yml

また actions/setup-node@v3 のバージョンは、現状の Vercel の Build 環境の Node Version と合わせました。